### PR TITLE
feat(LAB-3719): fix multipolygons geojson to kili

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kili-formats"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = [{ name = "Kili Technology", email = "contact@kili-technology.com" }]
 license = { file = "LICENSE.txt" }

--- a/src/kili_formats/format/geojson/segmentation.py
+++ b/src/kili_formats/format/geojson/segmentation.py
@@ -67,7 +67,6 @@ def kili_segmentation_to_geojson_geometry(bounding_poly: List[Any]) -> Dict[str,
     if not bounding_poly:
         raise ValueError("Empty bounding_poly")
 
-    # Detect format: hierarchical vs flat
     is_hierarchical = _is_hierarchical_format(bounding_poly)
 
     if is_hierarchical:
@@ -123,15 +122,12 @@ def _is_hierarchical_format(bounding_poly):
 
     first_element = bounding_poly[0]
 
-    # If first element is a list, it's hierarchical
     if isinstance(first_element, list):
         return True
 
-    # If first element is a dict with 'normalizedVertices', it's flat
     if isinstance(first_element, dict) and "normalizedVertices" in first_element:
         return False
 
-    # Default to flat format
     return False
 
 
@@ -385,7 +381,6 @@ def geojson_polygon_feature_to_kili_segmentation_annotation(
     children = children or polygon["properties"].get("kili", {}).get("children", {})
     categories = categories or polygon["properties"]["kili"]["categories"]
 
-    # Determine mid
     annotation_mid = None
     if mid is not None:
         annotation_mid = str(mid)

--- a/src/kili_formats/format/geojson/segmentation.py
+++ b/src/kili_formats/format/geojson/segmentation.py
@@ -3,13 +3,14 @@
 from typing import Any, Dict, List, Optional
 
 
-def kili_segmentation_to_geojson_geometry(
-    bounding_poly: List[List[Dict[str, List[Dict[str, Any]]]]]
-) -> Dict[str, Any]:
+def kili_segmentation_to_geojson_geometry(bounding_poly: List[Any]) -> Dict[str, Any]:
     """Convert a Kili segmentation to a geojson polygon or multipolygon geometry.
 
     Args:
-        bounding_poly: A Kili segmentation bounding polygon. List of polygon groups, each containing rings
+        bounding_poly: A Kili segmentation bounding polygon.
+                      Can be either:
+                      - Hierarchical: List of polygon groups, each containing rings
+                      - Flat: List of ring dictionaries
 
     Returns:
         A geojson Polygon or MultiPolygon geometry.
@@ -49,34 +50,89 @@ def kili_segmentation_to_geojson_geometry(
                 [[[2, 2], [3, 2], [3, 3], [2, 2]]]   # Second polygon
             ]
         }
+
+        # Flat structure (single polygon)
+        >>> bounding_poly = [
+        ...     {'normalizedVertices': [{'x': 0, 'y': 0}, {'x': 1, 'y': 0}, {'x': 1, 'y': 1}]}
+        ... ]
+        >>> kili_segmentation_to_geojson_geometry(bounding_poly)
+        {
+            'type': 'Polygon',
+            'coordinates': [
+                [[0, 0], [1, 0], [1, 1], [0, 0]]
+            ]
+        }
         ```
     """
-    # Determine Polygon vs MultiPolygon based on number of groups
-    if len(bounding_poly) == 1:
-        # Single polygon (potentially with holes)
-        ret = {"type": "Polygon", "coordinates": []}
-        for ring_dict in bounding_poly[0]:
-            ring_coords = [[vertex["x"], vertex["y"]] for vertex in ring_dict["normalizedVertices"]]
-            # Ensure the first and last points are identical (closed ring)
-            if ring_coords[0] != ring_coords[-1]:
-                ring_coords.append(ring_coords[0])
-            ret["coordinates"].append(ring_coords)
-        return ret
-    else:
-        # MultiPolygon
-        ret = {"type": "MultiPolygon", "coordinates": []}
-        for polygon_group in bounding_poly:
-            polygon_coords = []
-            for ring_dict in polygon_group:
+    if not bounding_poly:
+        raise ValueError("Empty bounding_poly")
+
+    # Detect format: hierarchical vs flat
+    is_hierarchical = _is_hierarchical_format(bounding_poly)
+
+    if is_hierarchical:
+        # Hierarchical format: [ [ {normalizedVertices: [...]}, ... ], ... ]
+        if len(bounding_poly) == 1:
+            # Single polygon (potentially with holes)
+            ret = {"type": "Polygon", "coordinates": []}
+            for ring_dict in bounding_poly[0]:
                 ring_coords = [
                     [vertex["x"], vertex["y"]] for vertex in ring_dict["normalizedVertices"]
                 ]
                 # Ensure the first and last points are identical (closed ring)
-                if ring_coords[0] != ring_coords[-1]:
+                if ring_coords and ring_coords[0] != ring_coords[-1]:
                     ring_coords.append(ring_coords[0])
-                polygon_coords.append(ring_coords)
-            ret["coordinates"].append(polygon_coords)
+                ret["coordinates"].append(ring_coords)
+            return ret
+        else:
+            # MultiPolygon
+            ret = {"type": "MultiPolygon", "coordinates": []}
+            for polygon_group in bounding_poly:
+                polygon_coords = []
+                for ring_dict in polygon_group:
+                    ring_coords = [
+                        [vertex["x"], vertex["y"]] for vertex in ring_dict["normalizedVertices"]
+                    ]
+                    # Ensure the first and last points are identical (closed ring)
+                    if ring_coords and ring_coords[0] != ring_coords[-1]:
+                        ring_coords.append(ring_coords[0])
+                    polygon_coords.append(ring_coords)
+                ret["coordinates"].append(polygon_coords)
+            return ret
+    else:
+        # Flat format: [ {normalizedVertices: [...]}, ... ]
+        # Treat as single polygon with multiple rings (exterior + holes)
+        ret = {"type": "Polygon", "coordinates": []}
+        for ring_dict in bounding_poly:
+            ring_coords = [[vertex["x"], vertex["y"]] for vertex in ring_dict["normalizedVertices"]]
+            # Ensure the first and last points are identical (closed ring)
+            if ring_coords and ring_coords[0] != ring_coords[-1]:
+                ring_coords.append(ring_coords[0])
+            ret["coordinates"].append(ring_coords)
         return ret
+
+
+def _is_hierarchical_format(bounding_poly):
+    """Check if boundingPoly is in hierarchical format.
+
+    Hierarchical: [ [ {normalizedVertices: [...]}, ... ], ... ]
+    Flat: [ {normalizedVertices: [...]}, ... ]
+    """
+    if not bounding_poly or len(bounding_poly) == 0:
+        return False
+
+    first_element = bounding_poly[0]
+
+    # If first element is a list, it's hierarchical
+    if isinstance(first_element, list):
+        return True
+
+    # If first element is a dict with 'normalizedVertices', it's flat
+    if isinstance(first_element, dict) and "normalizedVertices" in first_element:
+        return False
+
+    # Default to flat format
+    return False
 
 
 def kili_segmentation_annotation_to_geojson_polygon_feature(
@@ -158,6 +214,36 @@ def kili_segmentation_annotation_to_geojson_polygon_feature(
                 }
             }
         }
+
+        # Flat format annotation
+        >>> segmentation = {
+        ...     'children': {},
+        ...     'boundingPoly': [
+        ...         {'normalizedVertices': [{'x': 0, 'y': 0}, {'x': 1, 'y': 0}, {'x': 1, 'y': 1}]}
+        ...     ],
+        ...     'categories': [{'name': 'object'}],
+        ...     'mid': 'object_001',
+        ...     'type': 'semantic'
+        ... }
+        >>> kili_segmentation_annotation_to_geojson_polygon_feature(segmentation, 'detection_job')
+        {
+            'type': 'Feature',
+            'geometry': {
+                'type': 'Polygon',
+                'coordinates': [
+                    [[0, 0], [1, 0], [1, 1], [0, 0]]
+                ]
+            },
+            'id': 'object_001',
+            'properties': {
+                'kili': {
+                    'categories': [{'name': 'object'}],
+                    'children': {},
+                    'type': 'semantic',
+                    'job': 'detection_job'
+                }
+            }
+        }
         ```
     """
     assert (
@@ -191,10 +277,11 @@ def geojson_polygon_feature_to_kili_segmentation_annotation(
     categories: Optional[List[Dict]] = None,
     children: Optional[Dict] = None,
     mid: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Convert a geojson polygon feature to a Kili segmentation annotation.
+) -> List[Dict[str, Any]]:
+    """Convert a geojson polygon feature to a list of Kili segmentation annotations.
 
-    Supports both Polygon and MultiPolygon geometries.
+    For Polygon: returns a single annotation.
+    For MultiPolygon: returns N annotations (one per polygon part) with the same mid.
 
     Args:
         polygon: A geojson polygon feature.
@@ -206,11 +293,11 @@ def geojson_polygon_feature_to_kili_segmentation_annotation(
             If not provided, the mid is taken from the `id` key of the geojson feature.
 
     Returns:
-        A Kili segmentation annotation with hierarchical boundingPoly structure.
+        A list of Kili segmentation annotations. Each annotation has a flat boundingPoly structure.
 
     !!! Example
         ```python
-        # Polygon feature
+        # Polygon feature -> single annotation
         >>> polygon = {
         ...     'type': 'Feature',
         ...     'geometry': {
@@ -225,26 +312,25 @@ def geojson_polygon_feature_to_kili_segmentation_annotation(
         ...         'kili': {
         ...             'categories': [{'name': 'building'}],
         ...             'children': {},
-        ...             'type': 'semantic',
-        ...             'job': 'detection_job'
+        ...             'type': 'semantic'
         ...         }
         ...     }
         ... }
         >>> geojson_polygon_feature_to_kili_segmentation_annotation(polygon)
-        {
-            'children': {},
-            'boundingPoly': [
-                [  # Single polygon group
+        [
+            {
+                'children': {},
+                'boundingPoly': [
                     {'normalizedVertices': [{'x': 0, 'y': 0}, {'x': 1, 'y': 0}, {'x': 1, 'y': 1}]},
                     {'normalizedVertices': [{'x': 0.2, 'y': 0.2}, {'x': 0.8, 'y': 0.2}, {'x': 0.8, 'y': 0.8}]}
-                ]
-            ],
-            'categories': [{'name': 'building'}],
-            'mid': 'building_001',
-            'type': 'semantic'
-        }
+                ],
+                'categories': [{'name': 'building'}],
+                'mid': 'building_001',
+                'type': 'semantic'
+            }
+        ]
 
-        # MultiPolygon feature
+        # MultiPolygon feature -> multiple annotations with same mid
         >>> multipolygon = {
         ...     'type': 'Feature',
         ...     'geometry': {
@@ -264,16 +350,26 @@ def geojson_polygon_feature_to_kili_segmentation_annotation(
         ...     }
         ... }
         >>> geojson_polygon_feature_to_kili_segmentation_annotation(multipolygon)
-        {
-            'children': {},
-            'boundingPoly': [
-                [{'normalizedVertices': [{'x': 0, 'y': 0}, {'x': 1, 'y': 0}, {'x': 1, 'y': 1}]}],
-                [{'normalizedVertices': [{'x': 2, 'y': 2}, {'x': 3, 'y': 2}, {'x': 3, 'y': 3}]}]
-            ],
-            'categories': [{'name': 'forest'}],
-            'mid': 'forest_001',
-            'type': 'semantic'
-        }
+        [
+            {
+                'children': {},
+                'boundingPoly': [
+                    {'normalizedVertices': [{'x': 0, 'y': 0}, {'x': 1, 'y': 0}, {'x': 1, 'y': 1}]}
+                ],
+                'categories': [{'name': 'forest'}],
+                'mid': 'forest_001',
+                'type': 'semantic'
+            },
+            {
+                'children': {},
+                'boundingPoly': [
+                    {'normalizedVertices': [{'x': 2, 'y': 2}, {'x': 3, 'y': 2}, {'x': 3, 'y': 3}]}
+                ],
+                'categories': [{'name': 'forest'}],
+                'mid': 'forest_001',
+                'type': 'semantic'
+            }
+        ]
         ```
     """
     assert (
@@ -289,35 +385,49 @@ def geojson_polygon_feature_to_kili_segmentation_annotation(
     children = children or polygon["properties"].get("kili", {}).get("children", {})
     categories = categories or polygon["properties"]["kili"]["categories"]
 
-    ret = {
-        "children": children,
-        "categories": categories,
-        "type": "semantic",
-    }
+    # Determine mid
+    annotation_mid = None
+    if mid is not None:
+        annotation_mid = str(mid)
+    elif "id" in polygon:
+        annotation_mid = str(polygon["id"])
 
     coords = polygon["geometry"]["coordinates"]
+    annotations = []
 
     if geometry_type == "Polygon":
-        # Single polygon: wrap rings in a single group
-        ret["boundingPoly"] = [
-            [
+        # Single polygon: create one annotation
+        ret = {
+            "children": children,
+            "categories": categories,
+            "type": "semantic",
+            "boundingPoly": [
                 {"normalizedVertices": [{"x": coord[0], "y": coord[1]} for coord in ring[:-1]]}
                 for ring in coords
-            ]
-        ]
+            ],
+        }
+
+        if annotation_mid is not None:
+            ret["mid"] = annotation_mid
+
+        annotations.append(ret)
+
     else:
-        # MultiPolygon: each polygon becomes a separate group
-        ret["boundingPoly"] = [
-            [
-                {"normalizedVertices": [{"x": coord[0], "y": coord[1]} for coord in ring[:-1]]}
-                for ring in polygon_coords
-            ]
-            for polygon_coords in coords
-        ]
+        # MultiPolygon: create N annotations with same mid, one per polygon part
+        for polygon_coords in coords:
+            ret = {
+                "children": children,
+                "categories": categories,
+                "type": "semantic",
+                "boundingPoly": [
+                    {"normalizedVertices": [{"x": coord[0], "y": coord[1]} for coord in ring[:-1]]}
+                    for ring in polygon_coords
+                ],
+            }
 
-    if mid is not None:
-        ret["mid"] = str(mid)
-    elif "id" in polygon:
-        ret["mid"] = str(polygon["id"])
+            if annotation_mid is not None:
+                ret["mid"] = annotation_mid
 
-    return ret
+            annotations.append(ret)
+
+    return annotations

--- a/tests/test_geojson.py
+++ b/tests/test_geojson.py
@@ -511,10 +511,9 @@ class TestGeojsonSegmentationToKili:
             },
         }
         result = geojson_polygon_feature_to_kili_segmentation_annotation(polygon)
-        expected = {
-            "children": {},
-            "boundingPoly": [
-                [
+        expected = [
+            {
+                "boundingPoly": [
                     {"normalizedVertices": [{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}]},
                     {
                         "normalizedVertices": [
@@ -523,12 +522,13 @@ class TestGeojsonSegmentationToKili:
                             {"x": 0.8, "y": 0.8},
                         ]
                     },
-                ]
-            ],
-            "categories": [{"name": "building"}],
-            "mid": "building_001",
-            "type": "semantic",
-        }
+                ],
+                "categories": [{"name": "building"}],
+                "children": {},
+                "mid": "building_001",
+                "type": "semantic",
+            }
+        ]
         assert result == expected
 
     def test_geojson_polygon_feature_to_kili_segmentation_annotation_multipolygon(self):
@@ -547,16 +547,26 @@ class TestGeojsonSegmentationToKili:
             },
         }
         result = geojson_polygon_feature_to_kili_segmentation_annotation(multipolygon)
-        expected = {
-            "children": {},
-            "boundingPoly": [
-                [{"normalizedVertices": [{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}]}],
-                [{"normalizedVertices": [{"x": 2, "y": 2}, {"x": 3, "y": 2}, {"x": 3, "y": 3}]}],
-            ],
-            "categories": [{"name": "forest"}],
-            "mid": "forest_001",
-            "type": "semantic",
-        }
+        expected = [
+            {
+                "boundingPoly": [
+                    {"normalizedVertices": [{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}]}
+                ],
+                "categories": [{"name": "forest"}],
+                "children": {},
+                "mid": "forest_001",
+                "type": "semantic",
+            },
+            {
+                "boundingPoly": [
+                    {"normalizedVertices": [{"x": 2, "y": 2}, {"x": 3, "y": 2}, {"x": 3, "y": 3}]}
+                ],
+                "categories": [{"name": "forest"}],
+                "children": {},
+                "mid": "forest_001",
+                "type": "semantic",
+            },
+        ]
         assert result == expected
 
     def test_geojson_unsupported_geometry_type_raises_error(self):
@@ -1024,38 +1034,42 @@ class TestComplexScenarios:
             "SEMANTIC_JOB": {
                 "annotations": [
                     {
-                        "categories": [{"name": "forest"}],
                         "boundingPoly": [
-                            [  # First polygon group
-                                {
-                                    "normalizedVertices": [
-                                        {"x": 0.1, "y": 0.1},
-                                        {"x": 0.3, "y": 0.1},
-                                        {"x": 0.3, "y": 0.3},
-                                    ]
-                                },
-                                {
-                                    "normalizedVertices": [
-                                        {"x": 0.15, "y": 0.15},
-                                        {"x": 0.25, "y": 0.15},
-                                        {"x": 0.25, "y": 0.25},
-                                    ]
-                                },  # hole
-                            ],
-                            [  # Second polygon group
-                                {
-                                    "normalizedVertices": [
-                                        {"x": 0.5, "y": 0.5},
-                                        {"x": 0.7, "y": 0.5},
-                                        {"x": 0.7, "y": 0.7},
-                                    ]
-                                }
-                            ],
+                            {
+                                "normalizedVertices": [
+                                    {"x": 0.1, "y": 0.1},
+                                    {"x": 0.3, "y": 0.1},
+                                    {"x": 0.3, "y": 0.3},
+                                ]
+                            },
+                            {
+                                "normalizedVertices": [
+                                    {"x": 0.15, "y": 0.15},
+                                    {"x": 0.25, "y": 0.15},
+                                    {"x": 0.25, "y": 0.25},
+                                ]
+                            },
                         ],
+                        "categories": [{"name": "forest"}],
+                        "children": {},
                         "mid": "forest_complex",
                         "type": "semantic",
+                    },
+                    {
+                        "boundingPoly": [
+                            {
+                                "normalizedVertices": [
+                                    {"x": 0.5, "y": 0.5},
+                                    {"x": 0.7, "y": 0.5},
+                                    {"x": 0.7, "y": 0.7},
+                                ]
+                            }
+                        ],
+                        "categories": [{"name": "forest"}],
                         "children": {},
-                    }
+                        "mid": "forest_complex",
+                        "type": "semantic",
+                    },
                 ]
             }
         }


### PR DESCRIPTION
Fix GeoJSON conversion for multipart polygon to Kili format (where each part share the same mid)

________

**Complete E2E test :** 

- Draw annotations (with multi part polygons) on asset `1.tif` :
![Capture d’écran 2025-07-01 à 14 30 28](https://github.com/user-attachments/assets/1f3062eb-3256-4263-a019-43d348f72500)

- Export labels for `GeoJSON` format 

You should get this file `test.geojson` :  

https://drive.google.com/file/d/1GHMzeJ1x451oz7is2n73H537FU1bd8mJ/view?usp=drive_link

- Copy/paste the GeoJSON to https://geojson.io/ : you should see the annotations

![Capture d’écran 2025-07-01 à 14 34 31](https://github.com/user-attachments/assets/70c98ea2-9512-48cf-b46f-630d31b64f5c)

- Re-import the GeoJSON to another asset `2.tif` : 


```
from kili.client import Kili

kili = Kili(api_key="", api_endpoint='http://localhost:4001/api/label/v2/graphql')

project_id = "cmckcs45801l48g0w209s1d7q"

kili.append_labels_from_geojson_files(
    project_id=project_id,
    asset_external_id="2.tif",
    geojson_file_paths=['test.geojson']
)
```

You should see the annotations

![Capture d’écran 2025-07-01 à 14 30 51](https://github.com/user-attachments/assets/c6404f43-73ef-4882-b471-95b2b1bdfcf5)
