### PR TITLE
refactor(LAB-4397): remove unused format_json_response from kili-formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kili-formats"
-version = "1.4.0"
+version = "1.5.0"
 description = ""
 authors = [{ name = "Kili Technology", email = "contact@kili-technology.com" }]
 license = { file = "LICENSE.txt" }

--- a/src/kili_formats/__init__.py
+++ b/src/kili_formats/__init__.py
@@ -9,7 +9,7 @@ from .format.llm import (
 )
 from .format.voc import convert_from_kili_to_voc_format
 from .format.yolo import convert_from_kili_to_yolo_format
-from .kili import clean_json_response, convert_to_pixel_coords, format_json_response
+from .kili import clean_json_response, convert_to_pixel_coords
 
 __all__ = [
     "clean_json_response",
@@ -20,5 +20,4 @@ __all__ = [
     "convert_from_kili_to_voc_format",
     "convert_from_kili_to_yolo_format",
     "convert_to_pixel_coords",
-    "format_json_response",
 ]

--- a/src/kili_formats/kili.py
+++ b/src/kili_formats/kili.py
@@ -25,15 +25,6 @@ def clean_json_response(asset: Dict):
                 label["jsonResponse"].pop("ROTATION_JOB")
 
 
-def format_json_response(label):
-    """Format the label JSON response in the requested format."""
-    keys = list(label["jsonResponse"].keys())
-
-    for key in keys:
-        if key.isdigit():
-            label["jsonResponse"][int(key)] = label["jsonResponse"].pop(key)
-
-
 def convert_to_pixel_coords(asset: Dict, project: ProjectDict, **kwargs) -> Dict:
     """Convert asset JSON response normalized vertices to pixel coordinates."""
     if asset.get("latestLabel", {}):


### PR DESCRIPTION
Delete the dead public function format_json_response (zero callers) from src/kili_formats/kili.py and drop it from the package public API (__init__.py import + __all__). Bump version 1.4.0 -> 1.5.0 since a public symbol is removed from the package surface.